### PR TITLE
Use npm env for cache dir

### DIFF
--- a/local-cache.js
+++ b/local-cache.js
@@ -1,16 +1,17 @@
 var fs = require('fs')
 var path = require('path')
-var homedir = require('os').homedir
+
+var CACHE_DIR = process.env.npm_config_cache
 
 module.exports = function () {
   var reg = {}
 
   reg.fetchMetadata = function (pkg, done) {
-    var cacheMeta = path.join(homedir(), '.npm', 'registry.npmjs.org', pkg, '.cache.json')
+    var cacheMeta = path.join(CACHE_DIR, 'registry.npmjs.org', pkg, '.cache.json')
     if (fs.existsSync(cacheMeta)) {
       done(null, fs.readFileSync(cacheMeta, 'utf8'))
     } else {
-      cacheMeta = path.join(homedir(), '.npm', 'localhost_9001', pkg, '.cache.json')
+      cacheMeta = path.join(CACHE_DIR, 'localhost_9001', pkg, '.cache.json')
       if (fs.existsSync(cacheMeta)) {
         done(null, fs.readFileSync(cacheMeta, 'utf8'))
       } else {

--- a/scan-cache.js
+++ b/scan-cache.js
@@ -1,13 +1,14 @@
 var through = require('through2')
 var fs = require('fs')
-var homedir = require('os').homedir
 var path = require('path')
+
+var CACHE_DIR = process.env.npm_config_cache
 
 module.exports = function () {
   var t = through.obj()
 
   process.nextTick(function () {
-    var root = path.join(homedir(), '.npm')
+    var root = CACHE_DIR
     var dirs = fs.readdirSync(root)
     console.log('found', dirs.length)
     dirs.forEach(function (pkgDir) {

--- a/server.js
+++ b/server.js
@@ -5,7 +5,8 @@ var routes = require('routes')
 var url = require('url')
 var body = require('body')
 var mkdirp = require('mkdirp')
-var homedir = require('os').homedir
+
+var CACHE_DIR = process.env.npm_config_cache
 
 module.exports = function (done) {
   var router = routes()
@@ -76,7 +77,7 @@ module.exports = function (done) {
 
     var pkg = data.name
     var version = data['dist-tags'].latest
-    var dir = path.join(homedir(), '.npm', pkg, version)
+    var dir = path.join(CACHE_DIR, pkg, version)
 
     writeAttachments(pkg, attachments, dir, function (err) {
       if (err) return done(err)
@@ -92,7 +93,7 @@ module.exports = function (done) {
 
       // write cache entry
       setTimeout(function () {
-        var cacheDir = path.join(homedir(), '.npm', 'localhost_9001', pkg)
+        var cacheDir = path.join(CACHE_DIR, 'localhost_9001', pkg)
         mkdirp.sync(cacheDir)
         fs.writeFileSync(path.join(cacheDir, '.cache.json'), cacheJson, 'utf8')
         console.log('wrote cache meta', cacheDir)


### PR DESCRIPTION
On Windows the cache dir is `npm-cache` not `.npm`, and the user could change their cache location. https://docs.npmjs.com/cli/cache#cache